### PR TITLE
fix python3 open stopwords file UnicodeDecodeError bug

### DIFF
--- a/synonyms/__init__.py
+++ b/synonyms/__init__.py
@@ -104,7 +104,10 @@ def _load_stopwords(file_path):
     load stop words
     '''
     global _stopwords
-    words = open(file_path, 'r')
+    if sys.version_info[0] < 3:
+        words = open(file_path, 'r')
+    else:
+        words = open(file_path, 'r', encoding='utf-8')
     stopwords = words.readlines()
     for w in stopwords:
         _stopwords.add(any2unicode(w).strip())


### PR DESCRIPTION
修复了python3 open stopwords file报UnicodeDecodeError的错误
经过demo测试，python2和python3都OK