### PR TITLE
change import path of utils in word2vec.py to local path

### DIFF
--- a/synonyms/word2vec.py
+++ b/synonyms/word2vec.py
@@ -30,7 +30,7 @@ else:
 
 from absl import logging
 
-import utils
+from .utils import smart_open, to_unicode, cosine
 from numpy import dot, zeros, dtype, float32 as REAL,\
     double, array, vstack, fromstring, sqrt, newaxis,\
     ndarray, sum as np_sum, prod, ascontiguousarray,\
@@ -119,14 +119,14 @@ class KeyedVectors():
         if fvocab is not None:
             logging.debug("loading word counts from %s" % fvocab)
             counts = {}
-            with utils.smart_open(fvocab) as fin:
+            with smart_open(fvocab) as fin:
                 for line in fin:
-                    word, count = utils.to_unicode(line).strip().split()
+                    word, count = to_unicode(line).strip().split()
                     counts[word] = int(count)
 
         logging.debug("loading projection weights from %s" % fname)
-        with utils.smart_open(fname) as fin:
-            header = utils.to_unicode(fin.readline(), encoding=encoding)
+        with smart_open(fname) as fin:
+            header = to_unicode(fin.readline(), encoding=encoding)
             # throws for invalid file format
             vocab_size, vector_size = (int(x) for x in header.split())
             if limit:
@@ -178,7 +178,7 @@ class KeyedVectors():
                         # have)
                         if ch != b'\n':
                             word.append(ch)
-                    word = utils.to_unicode(
+                    word = to_unicode(
                         b''.join(word), encoding=encoding, errors=unicode_errors)
                     weights = fromstring(fin.read(binary_len), dtype=REAL)
                     add_word(word, weights)
@@ -188,7 +188,7 @@ class KeyedVectors():
                     if line == b'':
                         raise EOFError(
                             "unexpected end of input; is count incorrect or file otherwise damaged?")
-                    parts = utils.to_unicode(
+                    parts = to_unicode(
                         line.rstrip(),
                         encoding=encoding,
                         errors=unicode_errors).split(" ")
@@ -245,7 +245,7 @@ class KeyedVectors():
         for (x,y) in zip(points, distances):
             w = self.index2word[x]
             if w == word: s = 1.0
-            else: s = utils.cosine(v, self.syn0[x])
+            else: s = cosine(v, self.syn0[x])
             if s < 0: s = abs(s)
             words.append(w)
             scores[w] = min(s, 1.0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I have changed the import of utils in word2vec from simply
`import utils` to `from .utils import ...`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If the modification is not made, users of this module can not name his file `utils.py` in the local directory, as with `import utils` in synonyms, python prefers to search locally first. Accordingly, the `utils` in the synonyms code will be referred to local `utils`, errors hence occurs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
After the modification, I import the module and everything goes well. It's a simple modification and won't make any change to the logic

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [√] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [√] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
